### PR TITLE
make build work with PUBIC_URL set

### DIFF
--- a/build-example.sh
+++ b/build-example.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/sh
+export PUBLIC_URL=https://example.com/amcat
+npm run build
+echo "Do not forget to move the build directory to the appropriate directory for your web server, such as /var/www/html/amcat"

--- a/src/App.js
+++ b/src/App.js
@@ -19,23 +19,23 @@ import DocumentDetail from './components/DocumentDetail';
 // Change to add new components to the header
 // The first item will be the opening page after login
 const items = [
-  { label: 'Home', path: '/home', Component: Home },
+  { label: 'Home', path: './home', Component: Home },
   {
     label: 'Manage Projects',
-    path: '/indices',
+    path: './indices',
     position: 'left',
     Component: Indices,
   },
-  { label: 'Run Queries', path: '/query', Component: Query },
+  { label: 'Run Queries', path: './query', Component: Query },
   // { label: 'Browse Index', path: '/indexDetail', Component: IndexDetail },
   {
     label: 'Browse Document',
-    path: '/browseDocument',
+    path: './browseDocument',
     Component: DocumentDetail,
   },
   {
     label: 'Manage Users and Access',
-    path: '/userManagement',
+    path: './userManagement',
     position: 'right',
     Component: Admin,
   },

--- a/src/components/Admin.js
+++ b/src/components/Admin.js
@@ -50,12 +50,12 @@ class Admin extends React.Component {
       },
       {
         title: 'Current Project:',
-        path: '/indices',
+        path: './indices',
         prop: this.props.amcatIndex.name,
       },
       {
         title: 'Role in Project:',
-        path: '/userManagement',
+        path: './userManagement',
         prop: `${this.props.amcatIndex.role}`,
       },
     ];

--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -28,7 +28,7 @@ class Home extends React.Component {
       },
       {
         title: 'Role in Project:',
-        path: this.props.amcatIndex ? '/userManagement' : '/indices',
+        path: this.props.amcatIndex ? './userManagement' : '/indices',
         prop: this.props.amcatIndex
           ? `${this.props.amcatIndex.role}`
           : 'No Project Selected',
@@ -88,7 +88,7 @@ class Home extends React.Component {
       },
       {
         title: 'User Management',
-        path: this.props.amcatIndex ? '/userManagement' : '/indices',
+        path: this.props.amcatIndex ? './userManagement' : './indices',
         btnText: this.props.amcatIndex
           ? 'Manage User Access!'
           : 'No Project Selected',


### PR DESCRIPTION
When deploying not at root, but at https://example.com/amcat, one can set  PUBLIC_URL at build time to make links work. However, some links are non-relative, leading to not-working links in the build app. This PR should fix that (unless I overlooked some more links)