### PR TITLE
Runtime env

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,13 @@
         "@tailwindcss/typography": "^0.5.9",
         "@tanstack/react-query-devtools": "^5.14.0",
         "@types/cookies": "^0.7.10",
+        "@types/estree": "^1.0.7",
+        "@types/estree-jsx": "^1.0.5",
+        "@types/express": "^5.0.1",
+        "@types/hast": "^3.0.4",
+        "@types/mdast": "^4.0.4",
         "@types/randomcolor": "^0.5.9",
+        "@types/unist": "^3.0.3",
         "favicons": "^7.2.0",
         "prettier": "^3.1.1",
         "prettier-plugin-tailwindcss": "^0.5.9"
@@ -4087,9 +4093,9 @@
       }
     },
     "node_modules/@types/estree": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
-      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
+      "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==",
       "license": "MIT"
     },
     "node_modules/@types/estree-jsx": {
@@ -4102,15 +4108,14 @@
       }
     },
     "node_modules/@types/express": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.0.tgz",
-      "integrity": "sha512-DvZriSMehGHL1ZNLzi6MidnsDhUZM/x2pRdDIKdwbUNqqwHxMlRdkxtn6/EPKyqKpHqTl/4nRZsRNLpZxZRpPQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.1.tgz",
+      "integrity": "sha512-UZUw8vjpWFXuDnjFTh7/5c2TWDlQqeXHi6hcN7F2XSVT5P+WmUnnbFS3KA6Jnc6IsEqI2qCVu2bK0R0J4A8ZQQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^5.0.0",
-        "@types/qs": "*",
         "@types/serve-static": "*"
       }
     },

--- a/package.json
+++ b/package.json
@@ -72,7 +72,13 @@
     "@tailwindcss/typography": "^0.5.9",
     "@tanstack/react-query-devtools": "^5.14.0",
     "@types/cookies": "^0.7.10",
+    "@types/estree": "^1.0.7",
+    "@types/estree-jsx": "^1.0.5",
+    "@types/express": "^5.0.1",
+    "@types/hast": "^3.0.4",
+    "@types/mdast": "^4.0.4",
     "@types/randomcolor": "^0.5.9",
+    "@types/unist": "^3.0.3",
     "favicons": "^7.2.0",
     "prettier": "^3.1.1",
     "prettier-plugin-tailwindcss": "^0.5.9"

--- a/src/components/ClientProviders.tsx
+++ b/src/components/ClientProviders.tsx
@@ -90,7 +90,17 @@ export default function ClientProviders({ children }: { children: React.ReactNod
   const [queryClient] = useState(() => new QueryClient({ mutationCache, queryCache, defaultOptions }));
 
   if (isLoading) {
-    return <div>Loading configuration...</div>;
+    return (
+      <div className="flex items-center justify-center h-screen">
+        <img
+          src="/logo.png"
+          alt="AmCAT"
+          width={500}
+          height={500}
+          className="animate-spin mx-2 px-1"
+        />
+      </div>
+    );
   }
 
   return (

--- a/src/pages/api/config.ts
+++ b/src/pages/api/config.ts
@@ -1,0 +1,7 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  res.status(200).json({ 
+    amcatServer: process.env.AMCAT_SERVER || process.env.NEXT_PUBLIC_AMCAT_SERVER || 'http://localhost:5000'
+  });
+}


### PR DESCRIPTION
For the docker-compose to work properly, we need to be able to set runtime environment variables. `NEXT_PUBLIC_AMCAT_SERVER` was previously only set at built, as far as I understand. The ability to set `NEXT_PUBLIC_AMCAT_SERVER` in `.env.local` stays untouched. But this works now:

```bash
AMCAT_SERVER="http://localhost/amcat" npm run dev
```
If both `NEXT_PUBLIC_AMCAT_SERVER` and `AMCAT_SERVER` are set, `AMCAT_SERVER` takes precedence.